### PR TITLE
Add feature remove, closes #7

### DIFF
--- a/ait.go
+++ b/ait.go
@@ -14,16 +14,20 @@ func main() {
 		fmt.Println("Usage: ait [command]") //eventually add a real usage printout
 		return
 	}
+	if !cli.IsAITRepo() && args[0] != "init" {
+		fmt.Println("this isn't an ait repository. Run \"ait init\"" +
+			" before taking further action")
+	}
+	var err error
 	switch args[0] {
 	case "add":
-		err := cli.Add(args[1:])
-		if err != nil {
-			fmt.Println(err.Error())
-		}
+		err = cli.Add(args[1:])
 	case "status":
-		err := cli.Status()
-		if err != nil {
-			fmt.Println(err)
-		}
+		cli.Status()
+	case "remove":
+		err = cli.Remove(args[1:])
+	}
+	if err != nil {
+		fmt.Println( err.Error())
 	}
 }

--- a/cli/add.go
+++ b/cli/add.go
@@ -25,7 +25,7 @@ func Add(args []string) error {
         return err
     }
     contents := make(map[string]struct{}) //basically a set. empty struct has 0 width.
-    FillMap(contents, file)
+    fillMap(contents, file)
     file.Close()
     file, err = os.OpenFile(AddedFilesPath, os.O_TRUNC | os.O_WRONLY, 0644)
     //completely truncate the file to avoid duplicated filenames
@@ -42,11 +42,11 @@ func Add(args []string) error {
         })
     }
     //dump the map's keys, which have to be unique, into the file.
-    return DumpMap(contents, file)
+    return dumpMap(contents, file)
 }
 
 //Splits the given file by newline and adds each line to the given map.
-func FillMap(contents map[string]struct{}, file *os.File) {
+func fillMap(contents map[string]struct{}, file *os.File) {
     scanner := bufio.NewScanner(file)
     scanner.Split(bufio.ScanLines)
     for scanner.Scan() {
@@ -57,7 +57,7 @@ func FillMap(contents map[string]struct{}, file *os.File) {
 }
 
 //Dumps all keys in the given map to the given file, separated by a newline.
-func DumpMap(contents map[string]struct{}, file *os.File) error {
+func dumpMap(contents map[string]struct{}, file *os.File) error {
     for line := range contents {
         _, err := file.WriteString(line + "\n")
         if err != nil {

--- a/cli/add.go
+++ b/cli/add.go
@@ -3,7 +3,6 @@ package cli
 import (
     "bufio"
     "errors"
-    "github.com/minio/minio/pkg/wildcard"
     "os"
     "path/filepath"
 )
@@ -16,11 +15,8 @@ const AddedFilesPath string = ".ait/added_files" //can later be put somewhere mo
 //working directory. Along the way, the filenames are put in a hashmap, so the
 //specific order of the filenames in the file is unpredictable, but users should
 //not be directly interacting with files in .ait anyway.
+//TODO: prevent addition of files outside of the repo
 func Add(args []string) error {
-    if !IsAITRepo() {
-        return errors.New("this isn't an ait repository. Run \"ait init\"" +
-            " before taking further action")
-    }
     if len(args) == 0 {
         return errors.New("no files specified, nothing was done")
     }
@@ -29,7 +25,7 @@ func Add(args []string) error {
         return err
     }
     contents := make(map[string]struct{}) //basically a set. empty struct has 0 width.
-    fillMap(contents, file)
+    FillMap(contents, file)
     file.Close()
     file, err = os.OpenFile(AddedFilesPath, os.O_TRUNC | os.O_WRONLY, 0644)
     //completely truncate the file to avoid duplicated filenames
@@ -37,23 +33,20 @@ func Add(args []string) error {
         return err
     }
     defer file.Close()
-    for _, token := range args {
-        err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
-            if wildcard.Match(token, path) {
-                contents[path] = struct{}{}
+    for _, pattern := range args {
+        _ = filepath.Walk(".", func(fPath string, info os.FileInfo, err error) error {
+            if PathMatch(pattern, fPath) {
+                contents[fPath] = struct{}{}
             }
             return nil
         })
-        if err != nil {
-            return err
-        }
     }
     //dump the map's keys, which have to be unique, into the file.
-    return dumpMap(contents, file)
+    return DumpMap(contents, file)
 }
 
 //Splits the given file by newline and adds each line to the given map.
-func fillMap(contents map[string]struct{}, file *os.File) {
+func FillMap(contents map[string]struct{}, file *os.File) {
     scanner := bufio.NewScanner(file)
     scanner.Split(bufio.ScanLines)
     for scanner.Scan() {
@@ -64,7 +57,7 @@ func fillMap(contents map[string]struct{}, file *os.File) {
 }
 
 //Dumps all keys in the given map to the given file, separated by a newline.
-func dumpMap(contents map[string]struct{}, file *os.File) error {
+func DumpMap(contents map[string]struct{}, file *os.File) error {
     for line := range contents {
         _, err := file.WriteString(line + "\n")
         if err != nil {

--- a/cli/path_match.go
+++ b/cli/path_match.go
@@ -1,0 +1,13 @@
+package cli
+
+import "github.com/minio/minio/pkg/wildcard"
+
+//This function will need to have an algorithm for matching a path to a pattern that
+//goes beyond what wildcard.Match() can do.
+//Examples of things that wildcard.Match() will not cover but should:
+//  "./file" should match "file" if it's in the same directory
+//  "aDirectory" should be treated as "aDirectory/*", thus
+//  "aDirectory" should not be added as a file, only its contents
+func PathMatch(pattern, path string) bool {
+	return wildcard.Match(pattern, path)
+}

--- a/cli/remove.go
+++ b/cli/remove.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"bufio"
+	"errors"
+	"os"
+)
+
+//This method is the reverse of the add method. Given a set of file patterns, it
+//un-stages all files that match any of the patterns. It also takes a special arg
+//"--all" which will un-stage any and all files currently staged. Currently, this is
+//the same behavior as if it was passed "."
+//To remove lines from added_files, this function creates a temporary file which
+//holds all the lines that will stay from added_files, and at the end, it deletes
+//the original added_files and renames the temp file to be the new added_files.
+func Remove(args []string) error {
+	if !FileExists(AddedFilesPath) || GetFileSize(AddedFilesPath) == 0 {
+		return errors.New("no files currently staged, nothing was done")
+	} else if len(args) == 0 {
+		return errors.New("no files specified, nothing was done")
+	}
+	if args[0] == "--all" || args[0] == "." {
+		file, err := os.OpenFile(AddedFilesPath, os.O_TRUNC | os.O_WRONLY, 0644)
+		if err != nil {
+			return err
+		}
+		file.Close()
+		return nil
+	}
+	addedFiles, err1 := os.OpenFile(AddedFilesPath, os.O_RDONLY, 0644)
+	if err1 != nil {
+		return err1
+	}
+	tempFile, err2 := os.OpenFile(".ait/temp", os.O_WRONLY | os.O_CREATE, 0644)
+	if err2 != nil {
+		return err2
+	}
+	scanner := bufio.NewScanner(addedFiles)
+	scanner.Split(bufio.ScanLines)
+	for scanner.Scan() {
+		for _, pattern := range args {
+			if !PathMatch(pattern, scanner.Text()) {
+				_, err := tempFile.WriteString(scanner.Text() + "\n")
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	tempFile.Close()
+	addedFiles.Close()
+	err := os.Remove(AddedFilesPath)
+	if err != nil {
+		return err
+	}
+	return os.Rename(".ait/temp", AddedFilesPath)
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -15,7 +15,6 @@ func Init() {
 	} else if !info.IsDir() { //a non-dir file called ".ait" already exists
 
 	}
-
 }
 
 //trivial check to see if the program's working dir is an ait repo.
@@ -26,4 +25,13 @@ func IsAITRepo() bool {
 func FileExists(filename string) bool {
 	_, statErr := os.Stat(filename)
 	return !os.IsNotExist(statErr)
+}
+
+func GetFileSize(filename string) int64 {
+	info, err := os.Stat(filename)
+	if err != nil {
+		return 0
+	} else {
+		return info.Size()
+	}
 }

--- a/cli/status.go
+++ b/cli/status.go
@@ -2,19 +2,13 @@ package cli
 
 import (
     "bufio"
-    "errors"
     "fmt"
     "os"
     "sort"
 )
 
-//Simply prints out what files are currently staged for submission. Will return
-//an error if the working directory is not an ait repo.
-func Status() error {
-    if !IsAITRepo() {
-        return errors.New("this isn't an ait repository. Run \"ait init\"" +
-            " before taking further action")
-    }
+//Simply prints out what files are currently staged for submission.
+func Status() {
     file, err := os.OpenFile(AddedFilesPath, os.O_RDONLY, 0644)
     if err == nil {
         defer file.Close()
@@ -37,5 +31,4 @@ func Status() error {
     } else {
         fmt.Println("No files are currently staged for submission.")
     }
-    return nil
 }


### PR DESCRIPTION
Additonally, pretty much all the other code got a general clean-up. For
example, instead of each function checking if the program is running in
an AIT repo, this is done initially in `ait.go`. `Status()` no longer returns
an error because it doesn't need to. A utility function was added to
root.go which returns the size of a file.