### PR TITLE
Use filepath.Clean() to get desired pathmatching

### DIFF
--- a/cli/add.go
+++ b/cli/add.go
@@ -2,12 +2,11 @@ package cli
 
 import (
 	"bufio"
-	"fmt"
+	"github.com/DataDrake/cli-ng/cmd"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
-
-	"github.com/DataDrake/cli-ng/cmd"
 )
 
 // Add imports a file or directory to AIT's local staging file.
@@ -32,7 +31,6 @@ const addedFilesPath string = ".ait/added_files" //can later be put somewhere mo
 // working directory. Along the way, the filenames are put in a hashmap, so the
 // specific order of the filenames in the file is unpredictable, but users should
 // not be directly interacting with files in .ait anyway.
-// TODO: prevent addition of files outside of the repo
 func AddRun(_ *cmd.RootCMD, c *cmd.CMD) {
 	args := c.Args.(*AddArgs)
 
@@ -50,9 +48,9 @@ func AddRun(_ *cmd.RootCMD, c *cmd.CMD) {
 	}
 	defer file.Close()
 	for _, pattern := range args.Patterns {
-		fmt.Println(args.Patterns)
+		pattern = filepath.Clean(pattern)
 		_ = filepath.Walk(".", func(fPath string, info os.FileInfo, err error) error {
-			if PathMatch(pattern, fPath) {
+			if m, _ := path.Match(pattern, fPath); m {
 				contents[fPath] = struct{}{}
 			}
 			return nil

--- a/cli/remove.go
+++ b/cli/remove.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"log"
 	"os"
+	"path"
+	"path/filepath"
 
 	"github.com/DataDrake/cli-ng/cmd"
 )
@@ -36,6 +38,7 @@ type RemoveFlags struct {
 }
 
 // RemoveRun executes the remove function.
+//TODO: rewrite this function so that it actually works
 func RemoveRun(_ *cmd.RootCMD, c *cmd.CMD) {
 	flags := c.Flags.(*RemoveFlags)
 	args := c.Args.(*RemoveArgs)
@@ -61,9 +64,14 @@ func RemoveRun(_ *cmd.RootCMD, c *cmd.CMD) {
 	}
 	scanner := bufio.NewScanner(addedFiles)
 	scanner.Split(bufio.ScanLines)
+	contents := make(map[string]struct{})
 	for scanner.Scan() {
 		for _, pattern := range args.Patterns {
-			if !PathMatch(pattern, scanner.Text()) {
+			pattern = filepath.Clean(pattern)
+			m, _ := path.Match(pattern, scanner.Text())
+			_, contains := contents[scanner.Text()]
+			if !(m || contains) {
+				contents[scanner.Text()] = struct{}{}
 				_, err := tempFile.WriteString(scanner.Text() + "\n")
 				if err != nil {
 					log.Fatal(err)

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -2,8 +2,6 @@ package cli
 
 import (
 	"os"
-
-	"github.com/minio/minio/pkg/wildcard"
 )
 
 // IsAITRepo is a trivial check to see if the program's working dir is an ait repo.
@@ -23,14 +21,4 @@ func GetFileSize(filename string) int64 {
 		return 0
 	}
 	return info.Size()
-}
-
-// PathMatch will need to have an algorithm for matching a path to a pattern that
-//goes beyond what wildcard.Match() can do.
-//Examples of things that wildcard.Match() will not cover but should:
-//  "./file" should match "file" if it's in the same directory
-//  "aDirectory" should be treated as "aDirectory/*", thus
-//  "aDirectory" should not be added as a file, only its contents
-func PathMatch(pattern, path string) bool {
-	return wildcard.Match(pattern, path)
 }

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,4 @@ go 1.14
 
 require (
 	github.com/DataDrake/cli-ng v1.1.0
-	github.com/minio/minio v0.0.0-20200721013122-ec06089eda25
 )


### PR DESCRIPTION
That was less complicated than I thought so I was actually able to get rid of utils.PathMatch(). Also removed the minio wildcard dependency because I prefer the way filepath.Match() works: the * character will not match across directories (it will not match the os separator)