### PR TITLE
Reduce File Duplication in IPFS

### DIFF
--- a/ipfs/add.go
+++ b/ipfs/add.go
@@ -24,16 +24,20 @@ func Pin(hash string) (err error) {
 func Add(path string) (cid string, err error) {
 	file, err := getUnixfsNode(path)
 	if err != nil {
+		file.Close()
 		return cid, err
 	}
 	output, err := ipfs.Unixfs().Add(ctx, file, func(input *options.UnixfsAddSettings) error {
 		input.Pin = true
+		input.NoCopy = true
 		return nil
 	})
 	if err != nil {
+		file.Close()
 		return cid, err
 	}
 	cid = output.Cid().String()
+	file.Close()
 	return cid, nil
 }
 

--- a/ipfs/ipfs.go
+++ b/ipfs/ipfs.go
@@ -197,10 +197,11 @@ func createRepo(ctx context.Context, path string) (string, error) {
 		return "", err
 	}
 
-	cfg.Reprovider.Strategy = "all"
+	cfg.Reprovider.Strategy = "roots"
 	cfg.Reprovider.Interval = "1h"
 	cfg.Routing.Type = "dhtserver"
 	cfg.Swarm.EnableAutoRelay = true
+	cfg.Experimental.FilestoreEnabled = true
 
 	// Create the repo with the config
 	err = fsrepo.Init(path, cfg)

--- a/ipfs/provs.go
+++ b/ipfs/provs.go
@@ -1,9 +1,6 @@
 package ipfs
 
 import (
-	"context"
-	"time"
-
 	"github.com/ipfs/interface-go-ipfs-core/options"
 
 	icorepath "github.com/ipfs/interface-go-ipfs-core/path"
@@ -12,14 +9,12 @@ import (
 // FindProvs queries the IPFS network for the number of
 // providers hosting a given file
 func FindProvs(hash string, maxPeers int) (replications int, err error) {
-	contxt, cancl := context.WithTimeout(ctx, 2*time.Second)
 	path := icorepath.New("/ipfs/" + hash)
-	output, err := ipfs.Dht().FindProviders(contxt, path, func(input *options.DhtFindProvidersSettings) error {
+	output, err := ipfs.Dht().FindProviders(ctx, path, func(input *options.DhtFindProvidersSettings) error {
 		input.NumProviders = maxPeers
 		return nil
 	})
 	if err != nil {
-		cancl()
 		return -1, err
 	}
 	count := 0
@@ -27,7 +22,5 @@ func FindProvs(hash string, maxPeers int) (replications int, err error) {
 		_ = <-output
 		count++
 	}
-
-	cancl()
 	return count, nil
 }


### PR DESCRIPTION
We now support IPFS's filestore system to reduce file duplication when adding files to the IPFS store. Right now that means we have to symlink the working directory into the IPFS config location when IPFS needs to access files.