### PR TITLE
Refactor string sets

### DIFF
--- a/cli/add.go
+++ b/cli/add.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/DataDrake/cli-ng/cmd"
@@ -44,10 +45,10 @@ var threads int32 = 0
 func AddRun(_ *cmd.RootCMD, c *cmd.CMD) {
 	runtime.GOMAXPROCS(512) //TODO: assign this number meaningfully
 	args, exts := parseAddArgs(c)
-	contents := make(map[string]struct{}) //basically a set. empty struct has 0 width.
+	contents := types.NewThreadSafeStringSet()
 	file := utils.BasicFileOpen(utils.AddedFilesPath, os.O_CREATE|os.O_RDONLY, 0644)
 	utils.FillMap(contents, file)
-	origLen := len(contents)
+	origLen := contents.Size()
 	file.Close()
 	for _, userPath := range args {
 		userPath = filepath.Clean(userPath)
@@ -69,26 +70,23 @@ func AddRun(_ *cmd.RootCMD, c *cmd.CMD) {
 	//dump the map's keys, which have to be unique, into the file.
 	err := utils.DumpMap(contents, file)
 	utils.CheckError(err)
-	fmt.Println(len(contents) - origLen, "file(s) added")
+	fmt.Println(contents.Size() - origLen, "file(s) added")
 }
 
 // addPath attempts to add the given path to the current collection of added
 // files. No attempt will be made if the file doesn't exist or it is already
 // in the collection.
-func addPath(userPath string, contents map[string]struct{}) {
+func addPath(userPath string, contents *types.ThreadSafeStringSet) {
 	info, statErr := os.Stat(userPath)
-	_, alreadyContains := contents[userPath]
-	if !os.IsNotExist(statErr) && info != nil && !alreadyContains {
+	if !os.IsNotExist(statErr) && info != nil && !contents.Contains(userPath) {
 		// if file exists and isn't already in the map
 		if info.IsDir() {
-			c := make(chan string)
-			atomic.AddInt32(&threads, 1)
-			go processDir(userPath, c)
-			for msg := range c {
-				contents[msg] = struct{}{}
-			}
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+			go processDir(userPath, contents, &wg)
+			wg.Wait()
 		} else {
-			contents[userPath] = struct{}{}
+			contents.Add(userPath)
 		}
 	} else if os.IsNotExist(statErr) {
 		fmt.Printf("Path \"%v\" not found. Continuing...\n", userPath)
@@ -98,61 +96,58 @@ func addPath(userPath string, contents map[string]struct{}) {
 // processDir walks through the directory at dir and sends the path of all
 // regular files back to the main thread via c. If another directory is found,
 // another goproc is called to processDir that directory.
-func processDir(dir string, c chan string) {
-	defer func() {
-		atomic.AddInt32(&threads, -1)
-		if atomic.LoadInt32(&threads) <= 0 {
-			close(c)
-		}
-	}()
+func processDir(dir string, contents *types.ThreadSafeStringSet, wg *sync.WaitGroup) {
+	defer wg.Done()
 	if dir == ".ait" {
 		return
 	}
 	files, err := ioutil.ReadDir(dir)
-	utils.CheckError(err)
+	if err != nil {
+		fmt.Println("A thread encountered an error:", err)
+		return
+	}
 	for _, info := range files {
+		path := filepath.Join(dir, info.Name())
 		if info.IsDir() {
-			atomic.AddInt32(&threads, 1)
-			go processDir(filepath.Join(dir, info.Name()), c)
+			wg.Add(1)
+			go processDir(path, contents, wg)
 		} else {
-			c <- filepath.Join(dir, info.Name())
+			contents.Add(path)
 		}
 	}
 }
 
 // addExtension attempts to add ALL files within the current wd that have the
 // extension(s) contained in exts.
-func addExtension(contents map[string]struct{}, exts *types.StringSet) {
-	c := make(chan string)
+func addExtension(contents *types.ThreadSafeStringSet, exts *types.BasicStringSet) {
 	atomic.AddInt32(&threads, 1)
-	go processDirExt(".", c, exts)
-	for msg := range c {
-		contents[msg] = struct{}{}
-	}
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go processDirExt(".", exts, contents, &wg)
+	wg.Wait()
 }
 
 // processDirExt walks through the directory at dir and sends the path of all
 // regular files that have the desired file extensions back to the main thread
 // via c. If another directory is found, another goproc is called to
 // processDirExt that directory.
-func processDirExt(dir string, c chan string, exts *types.StringSet) {
-	defer func() {
-		atomic.AddInt32(&threads, -1)
-		if atomic.LoadInt32(&threads) <= 0 {
-			close(c)
-		}
-	}()
+func processDirExt(dir string, exts *types.BasicStringSet, contents *types.ThreadSafeStringSet, wg *sync.WaitGroup) {
+	defer wg.Done()
 	if dir == ".ait" {
 		return
 	}
 	files, err := ioutil.ReadDir(dir)
-	utils.CheckError(err)
+	if err != nil {
+		fmt.Println("A thread encountered an error:", err)
+		return
+	}
 	for _, info := range files {
+		path := filepath.Join(dir, info.Name())
 		if info.IsDir() {
-			atomic.AddInt32(&threads, 1)
-			go processDirExt(filepath.Join(dir, info.Name()), c, exts)
+			wg.Add(1)
+			go processDirExt(path, exts, contents, wg)
 		} else if exts.Contains(filepath.Ext(info.Name())) {
-			c <- filepath.Join(dir, info.Name())
+			contents.Add(path)
 		}
 	}
 }
@@ -160,12 +155,12 @@ func processDirExt(dir string, c chan string, exts *types.StringSet) {
 // parseAddArgs simply does some of the sanitization and extraction required to
 // get the desired data structures out of the cmd.CMD object, then returns said
 // useful data structures.
-func parseAddArgs(c *cmd.CMD) ([]string, *types.StringSet) {
+func parseAddArgs(c *cmd.CMD) ([]string, *types.BasicStringSet) {
 	var args []string
 	if c.Args != nil {
 		args = c.Args.(*AddArgs).Paths
 	}
-	var exts = types.NewStringSet()
+	var exts = types.NewBasicStringSet()
 	ind := utils.IndexOf(os.Args, "-e")
 	if c.Flags != nil && ind == -1 {
 		//They used the "... -e=png,jpg ..." syntax
@@ -189,8 +184,8 @@ func parseAddArgs(c *cmd.CMD) ([]string, *types.StringSet) {
 // splitExtensions takes a string like "png,pdf,jpg" and returns a sanitized set
 // of all extensions with no leading/trailing whitespace and no empty strings.
 // They will also have "." appended to them, ie "png,pdf" -> { ".png", ".pdf" }
-func splitExtensions(extStr string) *types.StringSet {
-	exts := types.NewStringSet()
+func splitExtensions(extStr string) *types.BasicStringSet {
+	exts := types.NewBasicStringSet()
 	for _, extension := range strings.Split(extStr, ",") {
 		extension = strings.TrimSpace(extension)
 		if len(extension) > 0 {

--- a/cli/benchmark_add_test.go
+++ b/cli/benchmark_add_test.go
@@ -84,19 +84,3 @@ func BenchmarkAddManyFiles(b *testing.B) {
 	fmt.Println("\n\t******** Adding files took", time.Since(start).Milliseconds(), "ms ********\n ")
 	_ = os.RemoveAll(testRoot + "/.ait")
 }
-
-//func TestUnicode(t *testing.T) {
-//	file, err := os.Create("日本語")
-//	utils.CheckError(err)
-//	info, _ := os.Stat(file.Name())
-//	s := info.Name()
-//	_ = os.Remove(file.Name())
-//	fmt.Println(s)
-//	file = utils.BasicFileOpen("utf8test",
-//		os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
-//	m := map[string]struct{}{ s: {} }
-//	err = utils.DumpMap(m, file)
-//	utils.CheckError(err)
-//	//remember to delete utf8test after checking to make sure s was printed
-//	//right and isn't a bunch of gibberish.
-//}

--- a/cli/remove.go
+++ b/cli/remove.go
@@ -51,7 +51,7 @@ func RemoveRun(_ *cmd.RootCMD, c *cmd.CMD) {
 	}
 	contents := types.NewBasicStringSet()
 	file := utils.BasicFileOpen(utils.AddedFilesPath, os.O_RDONLY, 0644)
-	utils.FillMap(contents, file)
+	utils.FillSet(contents, file)
 	file.Close()
 	numRMd := 0
 	if exts.Size() >0 && len(args) == 0 {
@@ -68,7 +68,7 @@ func RemoveRun(_ *cmd.RootCMD, c *cmd.CMD) {
 		}
 	}
 	file = utils.BasicFileOpen(utils.AddedFilesPath, os.O_WRONLY|os.O_TRUNC, 0644)
-	err := utils.DumpMap(contents, file)
+	err := utils.DumpSet(contents, file)
 	file.Close()
 	utils.CheckError(err)
 	fmt.Println(numRMd, "file(s) unstaged")

--- a/cli/remove.go
+++ b/cli/remove.go
@@ -49,7 +49,7 @@ func RemoveRun(_ *cmd.RootCMD, c *cmd.CMD) {
 		fmt.Println("All files unstaged")
 		return
 	}
-	contents := make(map[string]struct{})
+	contents := types.NewBasicStringSet()
 	file := utils.BasicFileOpen(utils.AddedFilesPath, os.O_RDONLY, 0644)
 	utils.FillMap(contents, file)
 	file.Close()
@@ -59,10 +59,10 @@ func RemoveRun(_ *cmd.RootCMD, c *cmd.CMD) {
 	}
 	for _, userPath := range args {
 		userPath = filepath.Clean(userPath)
-		for addedPath := range contents {
+		for addedPath := range contents.Underlying() {
 			if utils.IsInSubDir(addedPath, userPath) ||
 				exts.Contains(filepath.Ext(addedPath)) {
-				delete(contents, addedPath)
+				contents.Delete(addedPath)
 				numRMd++
 			}
 		}
@@ -77,13 +77,13 @@ func RemoveRun(_ *cmd.RootCMD, c *cmd.CMD) {
 // parseRmArgs simply does some of the sanitization and extraction required to
 // get the desired data structures out of the cmd.CMD object, then returns said
 // useful data structures.
-func parseRmArgs(c *cmd.CMD) ([]string, *types.StringSet, bool) {
+func parseRmArgs(c *cmd.CMD) ([]string, *types.BasicStringSet, bool) {
 	var args []string
 	if c.Args != nil {
 		args = c.Args.(*RemoveArgs).Paths
 	}
 	rmAll := false
-	exts := types.NewStringSet()
+	exts := types.NewBasicStringSet()
 	ind := utils.IndexOf(os.Args, "-e")
 	if c.Flags != nil && ind == -1 {
 		//They used the "... -e=png,jpg ..." syntax

--- a/cli/upload.go
+++ b/cli/upload.go
@@ -39,7 +39,7 @@ func UploadRun(r *cmd.RootCMD, c *cmd.CMD) {
 	flags := c.Flags.(*UploadFlags)
 	contents := types.NewBasicStringSet()
 	file := utils.BasicFileOpen(utils.AddedFilesPath, os.O_CREATE|os.O_RDONLY, 0644)
-	utils.FillMap(contents, file)
+	utils.FillSet(contents, file)
 	file.Close()
 
 	// In order to not copy files to ~/.ait/ipfs/ we need to create a workdir symlink

--- a/cli/upload.go
+++ b/cli/upload.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"github.com/arkenproject/ait/types"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -36,7 +37,7 @@ type UploadFlags struct {
 // UploadRun handles the uploading and display of the upload command.
 func UploadRun(r *cmd.RootCMD, c *cmd.CMD) {
 	flags := c.Flags.(*UploadFlags)
-	contents := make(map[string]struct{}) // basically a set. empty struct has 0 width.
+	contents := types.NewBasicStringSet()
 	file := utils.BasicFileOpen(utils.AddedFilesPath, os.O_CREATE|os.O_RDONLY, 0644)
 	utils.FillMap(contents, file)
 	file.Close()
@@ -55,11 +56,11 @@ func UploadRun(r *cmd.RootCMD, c *cmd.CMD) {
 	ipfs.Init()
 
 	fmt.Println("Adding Files to IPFS Store")
-	addBar := progressbar.Default(int64(len(contents)))
+	addBar := progressbar.Default(int64(contents.Size()))
 	addBar.RenderBlank()
 
-	input := make(chan string, len(contents))
-	for path := range contents {
+	input := make(chan string, contents.Size())
+	for path := range contents.Underlying() {
 		cid, err := ipfs.Add(filepath.Join(link, path))
 		utils.CheckError(err)
 
@@ -68,7 +69,7 @@ func UploadRun(r *cmd.RootCMD, c *cmd.CMD) {
 	}
 
 	fmt.Println("Uploading Files to Cluster")
-	ipfsBar := progressbar.Default(int64(len(contents)))
+	ipfsBar := progressbar.Default(int64(contents.Size()))
 	ipfsBar.RenderBlank()
 
 	for i := 0; i < workers; i++ {

--- a/keysets/generate.go
+++ b/keysets/generate.go
@@ -3,6 +3,7 @@ package keysets
 import (
 	"bufio"
 	"fmt"
+	"github.com/arkenproject/ait/types"
 	"os"
 	"path/filepath"
 	"strings"
@@ -53,20 +54,20 @@ func createNew(path string) error {
 	err = os.Symlink(wd, link)
 	defer os.Remove(link)
 
-	contents := make(map[string]struct{})
+	contents := types.NewBasicStringSet()
 	utils.FillMap(contents, addedFiles)
 	addedFiles.Close()
 
 	// For large Datasets display a loading bar.
-	ipfsBar := progressbar.Default(int64(len(contents)))
+	ipfsBar := progressbar.Default(int64(contents.Size()))
 	barPresent := false
-	if len(contents) > 30 {
+	if contents.Size() > 30 {
 		fmt.Println("Adding Files to Embedded IPFS Node:")
 		ipfsBar.RenderBlank()
 		barPresent = true
 	}
 
-	for filePath := range contents {
+	for filePath := range contents.Underlying() {
 		linkPath := filepath.Join(link, filePath)
 		line := getKeySetLineFromPath(linkPath)
 		_, err = keySetFile.WriteString(line + "\n")

--- a/keysets/generate.go
+++ b/keysets/generate.go
@@ -55,7 +55,7 @@ func createNew(path string) error {
 	defer os.Remove(link)
 
 	contents := types.NewBasicStringSet()
-	utils.FillMap(contents, addedFiles)
+	utils.FillSet(contents, addedFiles)
 	addedFiles.Close()
 
 	// For large Datasets display a loading bar.

--- a/types/basic_string_set.go
+++ b/types/basic_string_set.go
@@ -1,0 +1,46 @@
+package types
+
+// BasicStringSet is a simple container around a map[string]struct{}, whose values
+// have 0 width, so it has the functionality and performance of a hash-based set.
+type BasicStringSet struct {
+    internal map[string]struct{}
+}
+
+// NewBasicStringSet returns a pointer to a new BasicStringSet object
+func NewBasicStringSet() *BasicStringSet {
+    return  &BasicStringSet{
+        internal: make(map[string]struct{}),
+    }
+}
+
+// Contains returns true if the set contains str, false otherwise
+func (set *BasicStringSet) Contains(str string) bool {
+    _, ok := set.internal[str]
+    return ok
+}
+
+// Add adds the given string to the set
+func (set *BasicStringSet) Add(str string) {
+    set.internal[str] = struct{}{}
+}
+
+// Delete deletes the given string from the set
+func (set *BasicStringSet) Delete(str string) {
+    delete(set.internal, str)
+}
+
+// Size returns the amount of items in the set.
+func (set *BasicStringSet) Size() int {
+    return len(set.internal)
+}
+
+// Performs the given function on each element of the set
+func (set *BasicStringSet) ForEach(f func(s string)) {
+    for str := range set.internal {
+        f(str)
+    }
+}
+
+func (set *BasicStringSet) Underlying() map[string]struct{} {
+    return set.internal
+}

--- a/types/string_set.go
+++ b/types/string_set.go
@@ -1,42 +1,10 @@
 package types
 
-// StringSet is a simple container around a map[string]struct{}, whose values
-// have 0 width, so it has the functionality and performance of a hash-based set.
-type StringSet struct {
-    internal map[string]struct{}
-}
-
-// NewStringSet returns a pointer to a new StringSet object
-func NewStringSet() *StringSet {
-    return  &StringSet{
-        internal: make(map[string]struct{}),
-    }
-}
-
-// Contains returns true if the set contains str, false otherwise
-func (set *StringSet) Contains(str string) bool {
-    _, ok := set.internal[str]
-    return ok
-}
-
-// Add adds the given string to the set
-func (set *StringSet) Add(str string) {
-    set.internal[str] = struct{}{}
-}
-
-// Delete deletes the given string from the set
-func (set *StringSet) Delete(str string) {
-    delete(set.internal, str)
-}
-
-// Size returns the amount of items in the set.
-func (set *StringSet) Size() int {
-    return len(set.internal)
-}
-
-// Performs the given function on each element of the set
-func (set *StringSet) ForEach(f func(s string)) {
-    for str := range set.internal {
-        f(str)
-    }
+type StringSet interface {
+	Contains(string) bool
+	Add(string)
+	Delete(string)
+	Size() int
+	ForEach(func (string))
+	Underlying() map[string]struct{}
 }

--- a/types/threadsafe_string_set.go
+++ b/types/threadsafe_string_set.go
@@ -1,0 +1,58 @@
+package types
+
+import "sync"
+
+// ThreadSafeStringSet is a simple container around a map[string]struct{}, whose values
+// have 0 width, so it has the functionality and performance of a hash-based set.
+type ThreadSafeStringSet struct {
+	internal map[string]struct{}
+	sync.RWMutex
+}
+
+// NewThreadSafeStringSet returns a pointer to a new ThreadSafeStringSet object
+func NewThreadSafeStringSet() *ThreadSafeStringSet {
+	return  &ThreadSafeStringSet{
+		internal: make(map[string]struct{}),
+	}
+}
+
+// Contains returns true if the set contains str, false otherwise
+func (set *ThreadSafeStringSet) Contains(str string) bool {
+	_, ok := set.internal[str]
+	return ok
+}
+
+// Add adds the given string to the set
+func (set *ThreadSafeStringSet) Add(str string) {
+	set.Lock()
+	set.internal[str] = struct{}{}
+	set.Unlock()
+}
+
+// Delete deletes the given string from the set
+func (set *ThreadSafeStringSet) Delete(str string) {
+	set.Lock()
+	delete(set.internal, str)
+	set.Unlock()
+}
+
+// Size returns the amount of items in the set.
+func (set *ThreadSafeStringSet) Size() int {
+	return len(set.internal)
+}
+
+// Performs the given function on each element of the set
+func (set *ThreadSafeStringSet) ForEach(f func(s string)) {
+	set.Lock()
+	set.RLock()
+	for str := range set.internal {
+		f(str)
+	}
+	set.Unlock()
+	set.RUnlock()
+}
+
+func (set *ThreadSafeStringSet) Underlying() map[string]struct{} {
+	return set.internal
+}
+

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"bufio"
 	"fmt"
+	"github.com/arkenproject/ait/types"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -39,20 +40,20 @@ func IsInSubDir(dir, pathToCheck string) bool {
 }
 
 // FillMap splits the given file by newline and adds each line to the given map.
-func FillMap(contents map[string]struct{}, file *os.File) {
+func FillMap(contents types.StringSet, file *os.File) {
 	scanner := bufio.NewScanner(file)
 	scanner.Split(bufio.ScanLines)
 	for scanner.Scan() {
 		if len(scanner.Text()) > 0 {
-			contents[scanner.Text()] = struct{}{}
+			contents.Add(scanner.Text())
 		}
 	}
 }
 
 // Dumps all keys in the given map to the given file, separated by a newline.
-func DumpMap(contents map[string]struct{}, file *os.File) error {
+func DumpMap(contents types.StringSet, file *os.File) error {
 	toDump := make([]byte, 0, 256)
-	for line := range contents {
+	for line := range contents.Underlying() {
 		bLine := []byte(line)
 		for i := 0; i < len(bLine); i++ {
 			toDump = append(toDump, bLine[i])

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -39,8 +39,8 @@ func IsInSubDir(dir, pathToCheck string) bool {
 	return strings.HasPrefix(dir, pathToCheck)
 }
 
-// FillMap splits the given file by newline and adds each line to the given map.
-func FillMap(contents types.StringSet, file *os.File) {
+// FillSet splits the given file by newline and adds each line to the given set.
+func FillSet(contents types.StringSet, file *os.File) {
 	scanner := bufio.NewScanner(file)
 	scanner.Split(bufio.ScanLines)
 	for scanner.Scan() {
@@ -50,8 +50,9 @@ func FillMap(contents types.StringSet, file *os.File) {
 	}
 }
 
-// Dumps all keys in the given map to the given file, separated by a newline.
-func DumpMap(contents types.StringSet, file *os.File) error {
+// DumpSet dumps all values in the given set into the given file, separated by
+// newlines.
+func DumpSet(contents types.StringSet, file *os.File) error {
 	toDump := make([]byte, 0, 256)
 	for line := range contents.Underlying() {
 		bLine := []byte(line)


### PR DESCRIPTION
Adds the `StringSet` interface, which is implemented by `BasicStringSet`, which has no bells or whistles, and `ThreadSafeStringSet`, which uses an RWMutex to enforce thread safety. The latter is now used in the multithreaded add functions, which for me at least yielded about a 20% improvement in real runtime as opposed to the channel approach. Also, as a result of the new set, the multithreading is now handled by a wait group, which is hopefully more reliable than the previous method.